### PR TITLE
Pass remaining REPL arguments on to lumo / planck

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,24 @@ To start one of the boostrapped repls you can
 
 start a lumo repl
 
-    calvin repl  
+    calvin repl
 
 start a planck repl
 
     calvin -p planck repl
 
+Any remaining arguments are passed on to lumo/planck, so you can do things like
+
+    calvin repl my_script.cljs
+    calvin repl --dumb-terminal
+    calvin repl -c src -m my-project.main
+    calvin repl --socket-repl 3333
+
 ### Dependencies
 To discover the dependecies of  a project
 
     calvin deps
-    
+
 Calvin assumes there is a lein project file in the current directory. It will read such
 file and resolve transitive dependencies
 

--- a/src/main/clojure/eginez/calvin/core.cljs
+++ b/src/main/clojure/eginez/calvin/core.cljs
@@ -144,11 +144,11 @@
           proc (.spawn nchild bin (clj->js args) (clj->js {:stdio [0 1 2] :shell true}))]
       proc)))
 
-(defn run-repl [platform cwd]
+(defn run-repl [platform cwd rest-args]
   (go
     (let [classpath (<! (resolve-classpath cwd))
           [bin args] (build-cmd-for-platform platform classpath)
-          proc (.spawn nchild bin (clj->js args) (clj->js {:stdio [0 1 2]}))]
+          proc (.spawn nchild bin (clj->js (concat args rest-args)) (clj->js {:stdio [0 1 2]}))]
       proc)))
 
 (def cli-options [["-h" "--help"]
@@ -170,7 +170,7 @@
         platform (:platform options)]
     (case (first arguments)
       "deps" (show-deps (.cwd nproc))
-      "repl" (run-repl platform (.cwd nproc))
+      "repl" (run-repl platform (.cwd nproc) (next arguments))
       "build" (run-build  (.cwd nproc) (or (second arguments) "dev"))
       nil (println help))))
 


### PR DESCRIPTION
In "repl" mode, instead of ignoring them, pass extra command line arguments on to the lumo or planck sub-process.

This makes it easy to run a lumo script that uses `project.clj` dependencies, without having to first compile in.

Also has other uses like adding `--dumb-terminal` when needed.

    calvin repl my_script.cljs
    calvin repl --dumb-terminal
    calvin repl -c src -m my-project.main
    calvin repl --socket-repl 3333

(thought, maybe "repl" should be aliased to "run"? as in `calvin run my_script.cljs`)